### PR TITLE
Remove dist/ folder from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/


### PR DESCRIPTION
Added `dist/` to `.gitignore` and removed the tracked files inside `dist/` since it contains build artifacts that are generated dynamically during the build step.

---
*PR created automatically by Jules for task [6559752175706437228](https://jules.google.com/task/6559752175706437228) started by @Memija*