### PR TITLE
Update HTTPS redirect to new domain and fix open redirect

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,7 +37,8 @@ app.use((req, res, next) => {
       // Use URL constructor for safe URL construction
       // This sanitizes the path and query parameters
       try {
-        const targetUrl = new URL(req.path, 'https://memija-typography.herokuapp.com');
+        const sanitizedPath = req.path.replace(/^[/\\]+/, '');
+        const targetUrl = new URL(sanitizedPath, 'https://memija.github.io/memija-typography/');
 
         if (req.query && Object.keys(req.query).length > 0) {
             // URLSearchParams handles encoding automatically
@@ -47,7 +48,7 @@ app.use((req, res, next) => {
         res.redirect(301, targetUrl.toString());
       } catch (error) {
         // Fallback for invalid URLs
-        res.redirect(301, 'https://memija-typography.herokuapp.com/');
+        res.redirect(301, 'https://memija.github.io/memija-typography/');
       }
     }
   }


### PR DESCRIPTION
This PR updates the domain that users are redirected to when they access the app over HTTP. The domain has been updated from `https://memija-typography.herokuapp.com` to `https://memija.github.io/memija-typography/`.

Additionally, it fixes an Open Redirect vulnerability by stripping leading slashes from `req.path` before appending it to the base URL, which correctly handles paths without treating them as protocol-relative URLs or incorrectly dropping the new domain's subdirectory.

---
*PR created automatically by Jules for task [17257668681113689303](https://jules.google.com/task/17257668681113689303) started by @Memija*