### PR TITLE
Fix linter warnings for prop types and accessibility

### DIFF
--- a/npm_output.log
+++ b/npm_output.log
@@ -1,0 +1,36 @@
+
+> open
+> webpack serve --mode development --open
+
+<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:3000/
+<i> [webpack-dev-server] On Your Network (IPv4): http://192.168.0.2:3000/
+<i> [webpack-dev-server] Content not from webpack is served from '/app/public' directory
+<i> [webpack-dev-server] 404s will fallback to '/index.html'
+assets by chunk 1.01 MiB (auxiliary name: main)
+  assets by path resources/fonts/ 929 KiB
+    asset resources/fonts/fontawesome-webfont.svg 434 KiB [emitted] [from: node_modules/font-awesome/fonts/fontawesome-webfont.svg?v=4.7.0] (auxiliary name: main)
+    asset resources/fonts/fontawesome-webfont.eot 162 KiB [emitted] [from: node_modules/font-awesome/fonts/fontawesome-webfont.eot?v=4.7.0] (auxiliary name: main)
+    asset resources/fonts/fontawesome-webfont.ttf 162 KiB [emitted] [from: node_modules/font-awesome/fonts/fontawesome-webfont.ttf?v=4.7.0] (auxiliary name: main)
+    asset resources/fonts/fontawesome-webfont.woff 95.7 KiB [emitted] [from: node_modules/font-awesome/fonts/fontawesome-webfont.woff?v=4.7.0] (auxiliary name: main)
+    asset resources/fonts/fontawesome-webfont.woff2 75.4 KiB [emitted] [from: node_modules/font-awesome/fonts/fontawesome-webfont.woff2?v=4.7.0] (auxiliary name: main)
+  asset background.jpg 86.8 KiB [emitted] [from: src/resources/images/background.jpg] (auxiliary name: main)
+  asset memija.png 22 KiB [emitted] [from: src/resources/logo/memija.png] (auxiliary name: main)
+asset main.8b17d06104ad7b05aa40.js 1.86 MiB [emitted] [immutable] (name: main)
+asset ./index.html 1.37 KiB [emitted]
+runtime modules 27.3 KiB 14 modules
+javascript modules 1.59 MiB
+  modules by path ./src/ 171 KiB
+    modules by path ./src/components/ 121 KiB 40 modules
+    modules by path ./src/configurations/*.js 1.29 KiB 4 modules
+    modules by path ./src/css/*.less 45.3 KiB 2 modules
+    + 3 modules
+  modules by path ./node_modules/ 1.42 MiB 47 modules
+asset modules 336 bytes (javascript) 1.17 MiB (asset)
+  modules by path ./node_modules/ 252 bytes (javascript) 1.06 MiB (asset)
+    modules by path ./node_modules/font-awesome/fonts/*.eot 84 bytes (javascript) 324 KiB (asset) 2 modules
+    + 4 modules
+  modules by path ./src/ 84 bytes (javascript) 109 KiB (asset)
+    ./src/resources/images/background.jpg 42 bytes (javascript) 86.8 KiB (asset) [built] [code generated]
+    ./src/resources/logo/memija.png 42 bytes (javascript) 22 KiB (asset) [built] [code generated]
+webpack 5.76.0 compiled successfully in 2926 ms

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "bootstrap": "^5.1.3",
         "font-awesome": "^4.7.0",
         "js-file-download": "^0.4.12",
+        "prop-types": "^15.8.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       },
@@ -11103,7 +11104,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11801,7 +11801,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -11813,7 +11812,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -22412,8 +22410,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
       "version": "1.13.4",
@@ -22894,7 +22891,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -22904,8 +22900,7 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "bootstrap": "^5.1.3",
     "font-awesome": "^4.7.0",
     "js-file-download": "^0.4.12",
+    "prop-types": "^15.8.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/src/components/edit/color/Color.js
+++ b/src/components/edit/color/Color.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 
 const Color = ({ onChange }) => {
@@ -27,6 +28,10 @@ const Color = ({ onChange }) => {
             </div>
         </div>
     );
+};
+
+Color.propTypes = {
+    onChange: PropTypes.func.isRequired
 };
 
 export default Color;

--- a/src/components/edit/direction/Direction.js
+++ b/src/components/edit/direction/Direction.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 
 class Direction extends React.Component {
@@ -32,5 +33,9 @@ class Direction extends React.Component {
         );
     }
 }
+
+Direction.propTypes = {
+    onChange: PropTypes.func.isRequired
+};
 
 export default Direction;

--- a/src/components/edit/font-size/FontSize.js
+++ b/src/components/edit/font-size/FontSize.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 
 class FontSize extends React.Component {
@@ -46,5 +47,9 @@ class FontSize extends React.Component {
         );
     }
 }
+
+FontSize.propTypes = {
+    onChange: PropTypes.func.isRequired
+};
 
 export default FontSize;

--- a/src/components/edit/letter-spacing/LetterSpacing.js
+++ b/src/components/edit/letter-spacing/LetterSpacing.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 
 class LetterSpacing extends React.Component {
@@ -35,5 +36,9 @@ class LetterSpacing extends React.Component {
         );
     }
 }
+
+LetterSpacing.propTypes = {
+    onChange: PropTypes.func.isRequired
+};
 
 export default LetterSpacing;

--- a/src/components/edit/line-height/LineHeight.js
+++ b/src/components/edit/line-height/LineHeight.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 
 class LineHeight extends React.Component {
@@ -29,5 +30,9 @@ class LineHeight extends React.Component {
         );
     }
 }
+
+LineHeight.propTypes = {
+    onChange: PropTypes.func.isRequired
+};
 
 export default LineHeight;

--- a/src/components/edit/text-align/TextAlign.js
+++ b/src/components/edit/text-align/TextAlign.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 
 class TextAlign extends React.Component {
@@ -43,7 +44,7 @@ class TextAlign extends React.Component {
                     <label htmlFor="text-align">Text align</label>
                 </div>
                 <div className="btn-group col-xs-6 col-sm-6 col-md-6 col-lg-6">
-                    <div
+                    <button
                         className="btn btn-default"
                         data-placement="top"
                         data-toggle="tooltip"
@@ -51,8 +52,8 @@ class TextAlign extends React.Component {
                         title="Set CSS text-align property value to left."
                     >
                         <i className="fa fa-align-left fa-lg"></i>
-                    </div>
-                    <div
+                    </button>
+                    <button
                         className="btn btn-default"
                         data-placement="top"
                         data-toggle="tooltip"
@@ -60,8 +61,8 @@ class TextAlign extends React.Component {
                         title="Set CSS text-align property value to right."
                     >
                         <i className="fa fa-align-right fa-lg"></i>
-                    </div>
-                    <div
+                    </button>
+                    <button
                         className="btn btn-default"
                         data-placement="top"
                         data-toggle="tooltip"
@@ -69,8 +70,8 @@ class TextAlign extends React.Component {
                         title="Set CSS text-align property value to center."
                     >
                         <i className="fa fa-align-center fa-lg"></i>
-                    </div>
-                    <div
+                    </button>
+                    <button
                         className="btn btn-default"
                         data-placement="top"
                         data-toggle="tooltip"
@@ -78,11 +79,15 @@ class TextAlign extends React.Component {
                         title="Set CSS text-align property value to justify."
                     >
                         <i className="fa fa-align-justify fa-lg"></i>
-                    </div>
+                    </button>
                 </div>
             </div>
         );
     }
 }
+
+TextAlign.propTypes = {
+    onChange: PropTypes.func.isRequired
+};
 
 export default TextAlign;

--- a/src/components/edit/text-decoration/TextDecoration.js
+++ b/src/components/edit/text-decoration/TextDecoration.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 
 class TextDecoration extends React.Component {
@@ -34,5 +35,9 @@ class TextDecoration extends React.Component {
         );
     }
 }
+
+TextDecoration.propTypes = {
+    onChange: PropTypes.func.isRequired
+};
 
 export default TextDecoration;

--- a/src/components/edit/text-indent/TextIndent.js
+++ b/src/components/edit/text-indent/TextIndent.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 
 class TextIndent extends React.Component {
@@ -35,5 +36,9 @@ class TextIndent extends React.Component {
         );
     }
 }
+
+TextIndent.propTypes = {
+    onChange: PropTypes.func.isRequired
+};
 
 export default TextIndent;

--- a/src/components/edit/text-overflow/TextOverflow.js
+++ b/src/components/edit/text-overflow/TextOverflow.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 
 class TextOverflow extends React.Component {
@@ -33,5 +34,9 @@ class TextOverflow extends React.Component {
         );
     }
 }
+
+TextOverflow.propTypes = {
+    onChange: PropTypes.func.isRequired
+};
 
 export default TextOverflow;

--- a/src/components/edit/text-shadow/TextShadow.js
+++ b/src/components/edit/text-shadow/TextShadow.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 import './TextShadowStyle.less';
 
@@ -92,5 +93,9 @@ class TextShadow extends React.Component {
         );
     }
 }
+
+TextShadow.propTypes = {
+    onChange: PropTypes.func.isRequired
+};
 
 export default TextShadow;

--- a/src/components/edit/text-transform/TextTransform.js
+++ b/src/components/edit/text-transform/TextTransform.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 
 class TextTransform extends React.Component {
@@ -34,5 +35,9 @@ class TextTransform extends React.Component {
         );
     }
 }
+
+TextTransform.propTypes = {
+    onChange: PropTypes.func.isRequired
+};
 
 export default TextTransform;

--- a/src/components/edit/white-space/WhiteSpace.js
+++ b/src/components/edit/white-space/WhiteSpace.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 
 class WhiteSpace extends React.Component {
@@ -35,5 +36,9 @@ class WhiteSpace extends React.Component {
         );
     }
 }
+
+WhiteSpace.propTypes = {
+    onChange: PropTypes.func.isRequired
+};
 
 export default WhiteSpace;

--- a/src/components/edit/word-spacing/WordSpacing.js
+++ b/src/components/edit/word-spacing/WordSpacing.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../EditStyle.less';
 
 class WordSpacing extends React.Component {
@@ -29,5 +30,9 @@ class WordSpacing extends React.Component {
         );
     }
 }
+
+WordSpacing.propTypes = {
+    onChange: PropTypes.func.isRequired
+};
 
 export default WordSpacing;

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import './InputStyle.less';
 
 const Input = ({ onChange }) => {
@@ -12,6 +13,10 @@ const Input = ({ onChange }) => {
             <textarea onChange={handleChange} placeholder="Start typing ..."></textarea>
         </div>
     );
+};
+
+Input.propTypes = {
+    onChange: PropTypes.func.isRequired
 };
 
 export default Input;

--- a/src/components/output/css-output/CSSOutput.js
+++ b/src/components/output/css-output/CSSOutput.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import fileDownload from 'js-file-download';
 import { Configuration } from '../../index';
 import '../OutputStyle.less';
@@ -17,7 +18,7 @@ class CSSOutput extends React.Component {
     saveToFile() {
         let fileNameAndType = Configuration.File.FileName + Configuration.File.FileType;
         let input = this.dataRef.current.textContent;
-        let formatedData = input.replace(/;/g, ';\r\n').replace('{', '{\r\n').replace('}', '}\r\n');
+        let formatedData = input.replaceAll(';', ';\r\n').replace('{', '{\r\n').replace('}', '}\r\n');
         fileDownload(formatedData, fileNameAndType);
     }
 
@@ -63,5 +64,21 @@ class CSSOutput extends React.Component {
         );
     }
 }
+
+CSSOutput.propTypes = {
+    color: PropTypes.string.isRequired,
+    direction: PropTypes.string.isRequired,
+    fontSize: PropTypes.string.isRequired,
+    letterSpacing: PropTypes.string.isRequired,
+    lineHeight: PropTypes.string.isRequired,
+    textAlign: PropTypes.string.isRequired,
+    textDecoration: PropTypes.string.isRequired,
+    textIndent: PropTypes.string.isRequired,
+    textOverflow: PropTypes.string.isRequired,
+    textShadow: PropTypes.string.isRequired,
+    textTransform: PropTypes.string.isRequired,
+    whiteSpace: PropTypes.string.isRequired,
+    wordSpacing: PropTypes.string.isRequired
+};
 
 export default CSSOutput;

--- a/src/components/output/view-output/ViewOutput.js
+++ b/src/components/output/view-output/ViewOutput.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '../OutputStyle.less';
 import './ViewOutputStyle.less';
 
@@ -26,5 +27,22 @@ class ViewOutput extends React.Component {
         );
     }
 }
+
+ViewOutput.propTypes = {
+    color: PropTypes.string.isRequired,
+    direction: PropTypes.string.isRequired,
+    fontSize: PropTypes.string.isRequired,
+    letterSpacing: PropTypes.string.isRequired,
+    lineHeight: PropTypes.string.isRequired,
+    textAlign: PropTypes.string.isRequired,
+    textDecoration: PropTypes.string.isRequired,
+    textIndent: PropTypes.string.isRequired,
+    textOverflow: PropTypes.string.isRequired,
+    textShadow: PropTypes.string.isRequired,
+    textTransform: PropTypes.string.isRequired,
+    whiteSpace: PropTypes.string.isRequired,
+    wordSpacing: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired
+};
 
 export default ViewOutput;


### PR DESCRIPTION
Fixes numerous code smells and bugs reported by linter related to missing prop validation (`onChange` and style props), non-native interactive elements for buttons, and outdated `String#replace` usage. All tests pass and linting is clear.

---
*PR created automatically by Jules for task [8070792942078286584](https://jules.google.com/task/8070792942078286584) started by @Memija*