### PR TITLE
Prefer `node:path` over `path`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const HtmlWebPackPlugin = require('html-webpack-plugin');
-const path = require('path');
+const path = require('node:path');
 
 const htmlWebPackPluginInstance = new HtmlWebPackPlugin({
     filename: './index.html',


### PR DESCRIPTION
Prefer `node:path` over `path` in `webpack.config.js`.

---
*PR created automatically by Jules for task [16940925051921426838](https://jules.google.com/task/16940925051921426838) started by @Memija*