### PR TITLE
Improve readability of edit component labels

### DIFF
--- a/src/components/edit/EditStyle.less
+++ b/src/components/edit/EditStyle.less
@@ -1,5 +1,11 @@
+@import '../../css/brand/ColorVariables.less';
+
 .edit {
     margin-bottom: 0px;
+
+    label {
+        color: @white;
+    }
 
     input,
     select {

--- a/src/components/output/css-output/CSSOutputStyle.less
+++ b/src/components/output/css-output/CSSOutputStyle.less
@@ -12,6 +12,7 @@
 
     .btn-default {
         border-color: @white;
+        color: @white;
         border-style: solid;
         border-width: 1px;
 


### PR DESCRIPTION
Fixes an issue where property names (labels) in the edit components were unreadable against the dark background. The labels now use the `@white` brand color for proper contrast.

---
*PR created automatically by Jules for task [5633141973003236674](https://jules.google.com/task/5633141973003236674) started by @Memija*